### PR TITLE
fix: 32bit compilation

### DIFF
--- a/k256/src/arithmetic/field/field_10x26.rs
+++ b/k256/src/arithmetic/field/field_10x26.rs
@@ -2,7 +2,7 @@
 //! Ported from https://github.com/bitcoin-core/secp256k1
 
 use crate::FieldBytes;
-use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "zeroize")]
 use elliptic_curve::zeroize::Zeroize;

--- a/k256/src/arithmetic/field/field_montgomery.rs
+++ b/k256/src/arithmetic/field/field_montgomery.rs
@@ -4,7 +4,7 @@ use crate::{
     arithmetic::util::{adc64, mac64, mac64_typemax, sbb64},
     FieldBytes,
 };
-use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "zeroize")]
 use elliptic_curve::zeroize::Zeroize;

--- a/k256/src/arithmetic/scalar/scalar_8x32.rs
+++ b/k256/src/arithmetic/scalar/scalar_8x32.rs
@@ -6,7 +6,7 @@ use crate::{
     FieldBytes,
 };
 use core::convert::TryInto;
-use elliptic_curve::subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "zeroize")]
 use elliptic_curve::zeroize::Zeroize;


### PR DESCRIPTION
Hi @LLFourn 

I'm updating some dependencies in [xmr-btc-swap](/comit-network/xmr-btc-swap) and found that the `armv7` target needed this for this crate to compile 

Tested with 

`cargo build --target armv7-unknown-linux-gnueabihf` 

Thanks!